### PR TITLE
Make "virtual-host-gatherer" code Python 2-3 compatible

### DIFF
--- a/virtual-host-gatherer/lib/gatherer/gatherer.py
+++ b/virtual-host-gatherer/lib/gatherer/gatherer.py
@@ -102,9 +102,9 @@ class Gatherer(object):
         params = dict()
         if not self.modules:
             self._load_modules()
-        for modname, inst in self.modules.items():
+        for modname, inst in list(self.modules.items()):
             moditem = OrderedDict([('module', modname)])
-            params[modname] = OrderedDict(moditem.items() + inst.parameters().items())
+            params[modname] = OrderedDict(list(moditem.items()) + list(inst.parameters().items()))
         return params
 
     def _run(self):

--- a/virtual-host-gatherer/lib/gatherer/modules/File.py
+++ b/virtual-host-gatherer/lib/gatherer/modules/File.py
@@ -25,8 +25,12 @@ from collections import OrderedDict
 import json
 
 try:
-    import urlparse
-    import urlgrabber
+    try:
+        import urllib.parse as urlparse
+        from urllib.request import urlopen
+    except ImportError:
+        import urlparse
+        from urllib2 import urlopen
     IS_VALID = True
 except ImportError as ex:
     IS_VALID = False
@@ -86,7 +90,7 @@ class File(WorkerInterface):
         if not urlparse.urlsplit(self.url).scheme:
             self.url = "file://%s" % self.url
         try:
-            output = json.loads(urlgrabber.urlread(str(self.url), timeout=300))
+            output = json.load(urlopen(str(self.url), timeout=300))
         except Exception as exc:
             self.log.error("Unable to fetch '{0}': {1}".format(str(self.url), exc))
             return None

--- a/virtual-host-gatherer/lib/gatherer/modules/File.py
+++ b/virtual-host-gatherer/lib/gatherer/modules/File.py
@@ -95,7 +95,7 @@ class File(WorkerInterface):
             self.log.error("Unable to fetch '{0}': {1}".format(str(self.url), exc))
             return None
         # pylint: disable=W1622
-        first = next(iter(list(output.values())))
+        first = next(iter(output.values()))
         if "vms" not in first:
             # run() should return a dict of host entries
             # but here the first value is a virtual host manager

--- a/virtual-host-gatherer/lib/gatherer/modules/File.py
+++ b/virtual-host-gatherer/lib/gatherer/modules/File.py
@@ -28,17 +28,13 @@ import pycurl
 try:
     try:
         import urllib.parse as urlparse
+        from io import BytesIO as StringIO
     except ImportError:
         import urlparse
+        from StringIO import StringIO
     IS_VALID = True
 except ImportError as ex:
     IS_VALID = False
-
-
-try:
-    from io import BytesIO as StringIO
-except ImportError:
-    from StringIO import StringIO
 
 
 def _urlopen(url=None, timeout=60):

--- a/virtual-host-gatherer/lib/gatherer/modules/File.py
+++ b/virtual-host-gatherer/lib/gatherer/modules/File.py
@@ -91,7 +91,7 @@ class File(WorkerInterface):
             self.log.error("Unable to fetch '{0}': {1}".format(str(self.url), exc))
             return None
         # pylint: disable=W1622
-        first = output.itervalues().next()
+        first = next(iter(list(output.values())))
         if "vms" not in first:
             # run() should return a dict of host entries
             # but here the first value is a virtual host manager

--- a/virtual-host-gatherer/lib/gatherer/modules/__init__.py
+++ b/virtual-host-gatherer/lib/gatherer/modules/__init__.py
@@ -17,15 +17,15 @@ Contains worker interface.
 """
 
 from __future__ import absolute_import
+from six import with_metaclass
 import abc
 
 
 # pylint: disable=abstract-class-not-used
-class WorkerInterface(object):
+class WorkerInterface(with_metaclass(abc.ABCMeta, object)):
     """
     Worker definition interface.
     """
-    __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
     def set_node(self, node):

--- a/virtual-host-gatherer/virtual-host-gatherer.changes
+++ b/virtual-host-gatherer/virtual-host-gatherer.changes
@@ -1,3 +1,5 @@
+- Make virtual-host-gather Python 2/3 compatible
+
 -------------------------------------------------------------------
 Mon Feb 26 14:22:25 CET 2018 - mc@suse.de
 

--- a/virtual-host-gatherer/virtual-host-gatherer.spec
+++ b/virtual-host-gatherer/virtual-host-gatherer.spec
@@ -36,6 +36,11 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  python-devel
 BuildRequires:  asciidoc
 BuildRequires:  libxslt-tools
+%if 0%{?build_py3}
+Requires:       python3-six
+%else
+Requires:       python2-six
+%endif
 %{py_requires}
 %if 0%{?suse_version} && 0%{?suse_version} <= 1110
 %{!?python_sitelib: %global python_sitelib %(python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}

--- a/virtual-host-gatherer/virtual-host-gatherer.spec
+++ b/virtual-host-gatherer/virtual-host-gatherer.spec
@@ -17,6 +17,13 @@
 
 %global with_susecloud 0
 
+%if 0%{?suse_version} > 1320
+# SLE15 builds on Python 3
+%global build_py3   1
+%endif
+%define pythonX %{?build_py3:python3}%{!?build_py3:python2}
+%define python_sitelib %(%{pythonX} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
+
 Name:           virtual-host-gatherer
 Version:        1.0.17
 Release:        1
@@ -27,11 +34,9 @@ Url:            http://www.suse.com
 Source0:        %{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  python-devel
-BuildRequires:  python-urlgrabber
 BuildRequires:  asciidoc
 BuildRequires:  libxslt-tools
 %{py_requires}
-Requires:       python-urlgrabber
 %if 0%{?suse_version} && 0%{?suse_version} <= 1110
 %{!?python_sitelib: %global python_sitelib %(python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
 %else

--- a/virtual-host-gatherer/virtual-host-gatherer.spec
+++ b/virtual-host-gatherer/virtual-host-gatherer.spec
@@ -39,10 +39,12 @@ BuildRequires:  libxslt-tools
 BuildRequires:  python3-devel
 BuildRequires:  python3-six
 Requires:       python3-six
+Requires:       python3-pycurl
 %else
 BuildRequires:  python-devel
 BuildRequires:  python2-six
 Requires:       python2-six
+Requires:       python-pycurl
 %endif
 %{py_requires}
 %if 0%{?suse_version} && 0%{?suse_version} <= 1110

--- a/virtual-host-gatherer/virtual-host-gatherer.spec
+++ b/virtual-host-gatherer/virtual-host-gatherer.spec
@@ -33,12 +33,15 @@ Group:          Development/Languages
 Url:            http://www.suse.com
 Source0:        %{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-BuildRequires:  python-devel
 BuildRequires:  asciidoc
 BuildRequires:  libxslt-tools
 %if 0%{?build_py3}
+BuildRequires:  python3-devel
+BuildRequires:  python3-six
 Requires:       python3-six
 %else
+BuildRequires:  python-devel
+BuildRequires:  python2-six
 Requires:       python2-six
 %endif
 %{py_requires}
@@ -85,10 +88,17 @@ Kubernetes connection module for gatherer
 %setup -q
 
 %build
-python setup.py build
+# Fixing shebang for Python 3
+%if 0%{?build_py3}
+for i in `find . -type f`;
+do
+    sed -i '1s=^#!/usr/bin/\(python\|env python\)[0-9.]*=#!/usr/bin/python3=' $i;
+done
+%endif
+%{pythonX} setup.py build
 
 %install
-python setup.py install --prefix=%{_prefix} --root=$RPM_BUILD_ROOT
+%{pythonX} setup.py install --prefix=%{_prefix} --root=$RPM_BUILD_ROOT
 
 %if ! 0%{with_susecloud}
 rm -f $RPM_BUILD_ROOT%{python_sitelib}/gatherer/modules/SUSECloud.py*
@@ -117,6 +127,12 @@ rm -rf %{buildroot}
 %{_bindir}/%{name}
 %{python_sitelib}/virtual_host_gatherer-*.egg-info
 %{python_sitelib}/gatherer/modules/File.py*
+%if 0%{?build_py3}
+%dir %{python_sitelib}/gatherer/__pycache__
+%dir %{python_sitelib}/gatherer/modules/__pycache__
+%{python_sitelib}/gatherer/__pycache__/*
+%{python_sitelib}/gatherer/modules/__pycache__/*
+%endif
 
 %files VMware
 %defattr(-,root,root,-)


### PR DESCRIPTION
This PR migrates the python code for the "virtual-host-gatherer" to be 2/3 compatible.

Summary of actions:
- Fix `urllib` and `urllib2` imports.
- Remove non-python3 `python-urlgrabber` dependency with `pycurl`.
- Solve metaclass problem with `python-six`.
- General code fixes.
- Fix spec file to build package for Python 2 and 3.

Tracks: https://github.com/SUSE/salt-board/issues/65