### PR TITLE
Port to Python3: Fix wrong python-six dependency on Python 2

### DIFF
--- a/virtual-host-gatherer/virtual-host-gatherer.spec
+++ b/virtual-host-gatherer/virtual-host-gatherer.spec
@@ -42,8 +42,8 @@ Requires:       python3-six
 Requires:       python3-pycurl
 %else
 BuildRequires:  python-devel
-BuildRequires:  python2-six
-Requires:       python2-six
+BuildRequires:  python-six
+Requires:       python-six
 Requires:       python-pycurl
 %endif
 %{py_requires}


### PR DESCRIPTION
This PR prevents a failure resolving `python2-six` package on OpenSUSE for Python 2 builds.