### PR TITLE
Cast "NodeState" to str to allow serialization on libcloud 2.8.1

### DIFF
--- a/virtual-host-gatherer/lib/gatherer/modules/AmazonEC2.py
+++ b/virtual-host-gatherer/lib/gatherer/modules/AmazonEC2.py
@@ -121,7 +121,7 @@ class AmazonEC2(WorkerInterface):
             if node.extra['availability'] == self.zone:
                 output[self.node_id]['vms'][node.name] = node.id
                 output[self.node_id]['optionalVmData'][node.name] = {}
-                output[self.node_id]['optionalVmData'][node.name]['vmState'] = node.state
+                output[self.node_id]['optionalVmData'][node.name]['vmState'] = str(node.state)
         return output
 
     def valid(self):

--- a/virtual-host-gatherer/lib/gatherer/modules/Azure.py
+++ b/virtual-host-gatherer/lib/gatherer/modules/Azure.py
@@ -123,7 +123,7 @@ class Azure(WorkerInterface):
             if node.extra['location'] == self.zone:
                 output[self.node_id]['vms'][node.name] = node.extra['properties']['vmId']
                 output[self.node_id]['optionalVmData'][node.name] = {}
-                output[self.node_id]['optionalVmData'][node.name]['vmState'] = node.state
+                output[self.node_id]['optionalVmData'][node.name]['vmState'] = str(node.state)
         return output
 
     def valid(self):

--- a/virtual-host-gatherer/lib/gatherer/modules/GoogleCE.py
+++ b/virtual-host-gatherer/lib/gatherer/modules/GoogleCE.py
@@ -121,7 +121,7 @@ class GoogleCE(WorkerInterface):
             if node.extra['zone'].name == self.zone:
                 output[self.node_id]['vms'][node.name] = node.id
                 output[self.node_id]['optionalVmData'][node.name] = {}
-                output[self.node_id]['optionalVmData'][node.name]['vmState'] = node.state
+                output[self.node_id]['optionalVmData'][node.name]['vmState'] = str(node.state)
         return output
 
     def valid(self):

--- a/virtual-host-gatherer/virtual-host-gatherer.changes
+++ b/virtual-host-gatherer/virtual-host-gatherer.changes
@@ -1,3 +1,5 @@
+- Cast to NodeState to str to allow serialization on libcloud 2.8.1 (bsc#1167052)
+
 -------------------------------------------------------------------
 Fri Sep 20 10:15:47 WEST 2019 - psuarezhernandez@suse.com
 


### PR DESCRIPTION
After switching to `libcloud == 2.8.1`, the `node.state` attribute is not longer string type but a custom `NodeState` object. This is causing issues when running `virtual-host-gatherer`:


```
INFO: Connect Azure Public Cloud
ERROR: Object of type 'NodeState' is not JSON serializable
General error: Object of type 'NodeState' is not JSON serializable
Traceback (most recent call last):
  File "/usr/bin/virtual-host-gatherer", line 64, in <module>
    main()
  File "/usr/bin/virtual-host-gatherer", line 52, in main
    Gatherer(options).main()
  File "/usr/lib/python3.6/site-packages/gatherer/gatherer.py", line 178, in main
    self._run()
  File "/usr/lib/python3.6/site-packages/gatherer/gatherer.py", line 148, in _run
    json.dump(output, input_file, sort_keys=True, indent=4, separators=(',', ': '))
  File "/usr/lib64/python3.6/json/__init__.py", line 179, in dump
    for chunk in iterable:
  File "/usr/lib64/python3.6/json/encoder.py", line 430, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/usr/lib64/python3.6/json/encoder.py", line 404, in _iterencode_dict
    yield from chunks
  File "/usr/lib64/python3.6/json/encoder.py", line 404, in _iterencode_dict
    yield from chunks
  File "/usr/lib64/python3.6/json/encoder.py", line 404, in _iterencode_dict
    yield from chunks
  [Previous line repeated 2 more times]
  File "/usr/lib64/python3.6/json/encoder.py", line 437, in _iterencode
    o = _default(o)
  File "/usr/lib64/python3.6/json/encoder.py", line 180, in default
    o.__class__.__name__)
TypeError: Object of type 'NodeState' is not JSON serializable
```

In order to allow JSON serialization, this PR first casts `node.state` to string as that's the expected value for this particular attribute. i.a. `stopped`, `running`, etc. 
