### PR TITLE
Use the right docker container for pylint

### DIFF
--- a/virtual-host-gatherer/Makefile
+++ b/virtual-host-gatherer/Makefile
@@ -1,5 +1,5 @@
 # Docker tests variables
-DOCKER_CONTAINER_NAME = suma-head-gatherer
+DOCKER_CONTAINER_NAME = systemsmanagement/uyuni/master/docker/containers/uyuni-master-gatherer
 DOCKER_REGISTRY       = ${DOCKER_REGISTRY}
 DOCKER_RUN_EXPORT     = "PYTHONPATH=/gatherer/"
 DOCKER_VOLUMES        = -v "$(CURDIR)/:/gatherer"


### PR DESCRIPTION
We now have public containers, generated at OBS.

I guess we don't need a changelog entry, since there's nothing else to submit, so no need to package and push this to OBS/IBS